### PR TITLE
Makes UNIX tzid detection a bit more robust when tzdata is installed

### DIFF
--- a/tzinfo/private/os/unix.rkt
+++ b/tzinfo/private/os/unix.rkt
@@ -8,45 +8,46 @@
 
 (provide detect-tzid/unix)
 
-(define (detect-tzid/unix zoneinfo-dir all-tzids)
+(define (detect-tzid/unix zoneinfo-dir default-zoneinfo-dir all-tzids)
   (or (tzid-from-env)
       (and zoneinfo-dir
-           (tzid-from-/etc/localtime zoneinfo-dir all-tzids))
+           (tzid-from-/etc/localtime zoneinfo-dir default-zoneinfo-dir all-tzids))
       (tzid-from-/etc/timezone)
       (tzid-from-/etc/TIMEZONE)
       (tzid-from-/etc/sysconfig/clock)
       (tzid-from-/etc/default/init)))
 
 
-(define (tzid-from-/etc/localtime zoneinfo-dir all-tzids)
+(define (tzid-from-/etc/localtime zoneinfo-dir default-zoneinfo-dir all-tzids)
   (define /etc/localtime "/etc/localtime")
   (define base-path (resolve-path zoneinfo-dir))
-  
+
   (define (find-matching-zone)
     (define size (file-size /etc/localtime))
     (define content (file->bytes /etc/localtime))
-    
+
     (for*/first ([tzid (in-list all-tzids)]
                  [f (in-value (build-path base-path tzid))]
                  #:when (and (= (file-size f) size)
                              (equal? (file->bytes f) content)))
       tzid))
-  
+
   (and (file-exists? /etc/localtime)
-       (let ([rel (find-relative-path base-path (resolve-path /etc/localtime))])
+       default-zoneinfo-dir
+       (let ([rel (find-relative-path default-zoneinfo-dir (resolve-path /etc/localtime))])
          (match (explode-path rel)
            [(cons 'up _) (find-matching-zone)]
            [_ (path->string rel)]))))
 
 (define (tzid-from-/etc/timezone)
   (define /etc/timezone "/etc/timezone")
-  
+
   (and (file-exists? /etc/timezone)
        (string-trim (file->string /etc/timezone))))
 
 (define (tzid-from-/etc/TIMEZONE)
   (define /etc/TIMEZONE "/etc/TIMEZONE")
-  
+
   (tzid-from-var /etc/TIMEZONE "TZ"))
 
 (define (tzid-from-/etc/sysconfig/clock)
@@ -56,12 +57,12 @@
 
 (define (tzid-from-/etc/default/init)
   (define /etc/default/init "/etc/default/init")
-  
+
   (tzid-from-var /etc/default/init "TZ"))
 
 (define (tzid-from-var file var)
   (define re (pregexp (string-append "^\\s*" var "\\s*=\\s*(\\S+)")))
-  
+
   (and (file-exists? file)
        (for*/last ([s (in-list (file->lines file))]
                    [m (in-value (regexp-match re s))]


### PR DESCRIPTION
If tzdata is installed, tzinfo's zoneinfo-dir is no longer the system's default zoneinfo-dir. But if /etc/localtime is a symlink, it's going to point *inside* the system's zoneinfo dir, not inside tzdata's. So, to turn the symlink's referent into a tzid, we need to use the system's directory path, regardless of what tzinfo is using.
