### PR TITLE
Changes manner of requiring tzdata package.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,8 +1,10 @@
 #lang info
 
 (define collection 'multi)
+(define version "0.3")
 (define deps (list "base"
                    "cldr-core"
                    "rackunit-lib"
-                   (list "tzdata" '#:platform 'windows)))
+                   (list "tzdata" '#:platform 'windows '#:version "0.3")))
+(define update-implies (list "tzdata"))
 (define build-deps '("racket-doc" "scribble-lib"))

--- a/tzinfo/main.rkt
+++ b/tzinfo/main.rkt
@@ -1,17 +1,10 @@
 #lang racket/base
 
-(require racket/contract/base
-         syntax/modresolve)
+(require racket/contract/base)
 
 (require "private/generics.rkt"
          "private/structs.rkt"
          "zoneinfo.rkt")
-
-;; Load the zoneinfo-data package, if it's installed
-;; (as it should be on Windows, for example).
-(define ZONEINFO-DATA
-  (and (file-exists? (resolve-module-path 'tzinfo/zoneinfo-data #f))
-       (dynamic-require 'tzinfo/zoneinfo-data 'ZONEINFO-DATA)))
 
 (provide (struct-out tzoffset)
          (struct-out tzgap)

--- a/tzinfo/zoneinfo.rkt
+++ b/tzinfo/zoneinfo.rkt
@@ -1,9 +1,32 @@
 #lang racket/base
 
-(require racket/contract/base)
+(require racket/contract/base
+         racket/match
+         racket/runtime-path
+         setup/getinfo
+         (for-syntax racket/base
+                     racket/match
+                     setup/getinfo))
 (require "private/generics.rkt"
-         "private/zoneinfo.rkt")
+         "private/zoneinfo.rkt"
+         (for-syntax "private/zoneinfo.rkt"))
 
 (provide/contract
  [current-zoneinfo-search-path (parameter/c (listof path-string?))]
  [make-zoneinfo-source         (-> tzinfo-source?)])
+
+
+;; Use the zoneinfo database from the tzdata package, if it's installed
+;; (as it should be on Windows, for example).
+(define-runtime-path-list tzdata-paths
+  (match (find-relevant-directories '(tzdata-zoneinfo-dir))
+    [(cons dir _)
+     (define relpath ((get-info/full dir) 'tzdata-zoneinfo-dir))
+     (define zoneinfo-dir (build-path dir relpath))
+
+     (current-zoneinfo-search-path (list zoneinfo-dir))
+     
+     (parameterize ([current-directory zoneinfo-dir])
+       (for/list ([f (in-directory)])
+         (list 'lib (path->string (build-path "tzinfo" relpath (path->string f))))))]
+    [_ '()]))


### PR DESCRIPTION
Instead of attempting to dynamic-require the tzdata package,
we search for a variable in its package info.rkt. Based on
that, we define runtime paths for the data files to allow
`raco exe` to pull them in, and we modify the zoneinfo search
path here, instead of in the tzdata package.