### PR TITLE
Changes to system time zone detection:

### DIFF
--- a/tzinfo/private/os/unix.rkt
+++ b/tzinfo/private/os/unix.rkt
@@ -1,23 +1,18 @@
 #lang racket/base
 
 (require racket/file
-         racket/function
-         racket/match
-         racket/path
          racket/string
          "env.rkt")
 
-(provide detect-tzid/unix)
+(provide unix-tzid-tests)
 
-(define (detect-tzid/unix default-zoneinfo-dir all-tzids)
-  (filter
-   identity
-   (list (tzid-from-env)
-         (tzid-from-/etc/localtime default-zoneinfo-dir all-tzids)
-         (tzid-from-/etc/timezone)
-         (tzid-from-/etc/TIMEZONE)
-         (tzid-from-/etc/sysconfig/clock)
-         (tzid-from-/etc/default/init))))
+(define (unix-tzid-tests default-zoneinfo-dir all-tzids)
+  (list tzid-from-env
+        (λ () (tzid-from-/etc/localtime default-zoneinfo-dir all-tzids))
+        tzid-from-/etc/timezone
+        tzid-from-/etc/TIMEZONE
+        tzid-from-/etc/sysconfig/clock
+        tzid-from-/etc/default/init))
 
 (define /etc/localtime "/etc/localtime")
 

--- a/tzinfo/private/os/windows.rkt
+++ b/tzinfo/private/os/windows.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require file/resource
+(require racket/function
+         file/resource
          cldr/core
          "env.rkt"
          "windows-registry.rkt")
@@ -8,10 +9,12 @@
 (provide detect-tzid/windows)
 
 (define (detect-tzid/windows)
-  (or (tzid-from-env)
-      (tzid-from-registry/vista)
-      (tzid-from-registry/nt)
-      (tzid-from-registry/95)))
+  (filter
+   identity
+   (list (tzid-from-env)
+         (tzid-from-registry/vista)
+         (tzid-from-registry/nt)
+         (tzid-from-registry/95))))
 
 (define (tzid-from-registry/vista)
   (windows->tzid

--- a/tzinfo/private/os/windows.rkt
+++ b/tzinfo/private/os/windows.rkt
@@ -1,20 +1,17 @@
 #lang racket/base
 
-(require racket/function
-         file/resource
+(require file/resource
          cldr/core
          "env.rkt"
          "windows-registry.rkt")
 
-(provide detect-tzid/windows)
+(provide windows-tzid-tests)
 
-(define (detect-tzid/windows)
-  (filter
-   identity
-   (list (tzid-from-env)
-         (tzid-from-registry/vista)
-         (tzid-from-registry/nt)
-         (tzid-from-registry/95))))
+(define (windows-tzid-tests)
+  (list tzid-from-env
+        tzid-from-registry/vista
+        tzid-from-registry/nt
+        tzid-from-registry/95))
 
 (define (tzid-from-registry/vista)
   (windows->tzid

--- a/tzinfo/private/zoneinfo.rkt
+++ b/tzinfo/private/zoneinfo.rkt
@@ -52,21 +52,21 @@
        (tabzone-id tab)))
 
    (define (detect-system-tzid zi)
-     (define candidates
+     (define tests
        (case (system-type)
          [(unix macosx)
-          (detect-tzid/unix
+          (unix-tzid-tests
            (find-zoneinfo-directory default-zoneinfo-search-path)
            (tzinfo->all-tzids zi))]
          [(windows)
-          (detect-tzid/windows)]
+          (windows-tzid-tests)]
          [else
           null]))
 
-     (for/first ([tzid (in-list candidates)]
-                 #:when (tzinfo-has-tzid? zi tzid))
-       (string->immutable-string tzid)))])
-
+     (for*/first ([test (in-list tests)]
+                  [candidate (in-value (test))]
+                  #:when (tzinfo-has-tzid? zi candidate))
+       (string->immutable-string candidate)))])
 
 (define (make-zoneinfo-source)
   (define dir (find-zoneinfo-directory))

--- a/tzinfo/private/zoneinfo.rkt
+++ b/tzinfo/private/zoneinfo.rkt
@@ -52,19 +52,20 @@
        (tabzone-id tab)))
 
    (define (detect-system-tzid zi)
-     (define candidate
+     (define candidates
        (case (system-type)
          [(unix macosx)
-          (detect-tzid/unix (zoneinfo-dir zi)
-                            (find-zoneinfo-directory default-zoneinfo-search-path)
-                            (tzinfo->all-tzids zi))]
+          (detect-tzid/unix
+           (find-zoneinfo-directory default-zoneinfo-search-path)
+           (tzinfo->all-tzids zi))]
          [(windows)
           (detect-tzid/windows)]
          [else
-          #f]))
+          null]))
 
-     (and (tzinfo-has-tzid? zi candidate)
-          (string->immutable-string candidate)))])
+     (for/first ([tzid (in-list candidates)]
+                 #:when (tzinfo-has-tzid? zi tzid))
+       (string->immutable-string tzid)))])
 
 
 (define (make-zoneinfo-source)


### PR DESCRIPTION
1. Instead of trying to use the results of the first test that
returns a string, we now accumulate all of the string results
in a list and take the first one that is a real IANA time zone
id.

2. On UNIX systems, the /etc/localtime test has been changed.
   a. The actual location of the zoneinfo directory is not useful
for this test, because it is allowed to be in a location that
the operating system does not know about. For example, if you
use the tzdata package, then tzinfo will make use of its
zoneinfo files, which do not live in the standard system
location. But to detect the system's time zone, we need to
make use of the system's own files.

   b. We recently encountered a case where /etc/localtime
was symlinked to a path in the system's zoneinfo directory, which
was, in turn, a symlink to a different file. The method we were
using find the path of the zoneinfo file failed, because we
followed the links all the way to the wrong file. (We wanted
the one in the middle.) So, now we simply iterate through all
possible time zone ids and test if the actual file that is
named by that id (in the zoneinfo directory) is the same as
the actual file named by /etc/localtime.

   c. We split out the case that checks for an /etc/localtime
that is a copy of (not a symlink to) a zoneinfo file. We could
have used this mechanism to handle the symlink case, too, but
this is the most expensive test, so it might be worth avoiding
when we can.
