### PR TITLE
Updates to work with new version of tzdata

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,10 +1,10 @@
 #lang info
 
 (define collection 'multi)
-(define version "0.3")
+(define version "0.4")
 (define deps (list "base"
                    "cldr-core"
                    "rackunit-lib"
-                   (list "tzdata" '#:platform 'windows '#:version "0.3")))
+                   (list "tzdata" '#:platform 'windows '#:version "0.4")))
 (define update-implies (list "tzdata"))
 (define build-deps '("racket-doc" "scribble-lib"))

--- a/tzinfo/scribblings/tzinfo.scrbl
+++ b/tzinfo/scribblings/tzinfo.scrbl
@@ -227,3 +227,17 @@ at the given local time in the given time zone, according to the tzinfo source.
 Returns the time zone ID currently in use by the operating system, if it can be detected,
 @racket[#f] otherwise.
 }
+
+@section{Building standalone executables that use @tt{tzinfo}}
+
+If you build a standalone executable (with @tt{raco exe}) that uses this library,
+you should keep in mind where you intend to deploy it. Most UNIX / MacOS systems
+come with the zoneinfo database installed, but Windows systems do not, nor do some
+minimal UNIX systems.
+
+To ensure that the target system will be able to find and use zoneinfo files,
+you should install the @tt{tzdata} package. (When you install @tt{tzinfo} on a
+Windows system, @tt{tzdata} is automatically installed.) Then, when you
+build your executable, be sure to include the @tt{tzdata} library:
+
+@commandline{raco exe ++lib tzinfo/tzdata application app.exe}

--- a/tzinfo/zoneinfo.rkt
+++ b/tzinfo/zoneinfo.rkt
@@ -2,31 +2,23 @@
 
 (require racket/contract/base
          racket/match
-         racket/runtime-path
-         setup/getinfo
-         (for-syntax racket/base
-                     racket/match
-                     setup/getinfo))
+         setup/getinfo)
 (require "private/generics.rkt"
-         "private/zoneinfo.rkt"
-         (for-syntax "private/zoneinfo.rkt"))
+         "private/zoneinfo.rkt")
 
 (provide/contract
  [current-zoneinfo-search-path (parameter/c (listof path-string?))]
  [make-zoneinfo-source         (-> tzinfo-source?)])
 
 
-;; Use the zoneinfo database from the tzdata package, if it's installed
-;; (as it should be on Windows, for example).
-(define-runtime-path-list tzdata-paths
-  (match (find-relevant-directories '(tzdata-zoneinfo-dir))
-    [(cons dir _)
-     (define relpath ((get-info/full dir) 'tzdata-zoneinfo-dir))
-     (define zoneinfo-dir (build-path dir relpath))
+;; If the tzdata package is installed, put its zoneinfo directory at
+;; the head of the search path.
+(match (find-relevant-directories '(tzdata-zoneinfo-dir))
+  [(? pair?)
+   (define tzdata-zoneinfo-dir
+     (simplify-path (dynamic-require 'tzinfo/tzdata 'tzdata-zoneinfo-dir)))
 
-     (current-zoneinfo-search-path (list zoneinfo-dir))
-     
-     (parameterize ([current-directory zoneinfo-dir])
-       (for/list ([f (in-directory)])
-         (list 'lib (path->string (build-path "tzinfo" relpath (path->string f))))))]
-    [_ '()]))
+   (current-zoneinfo-search-path
+    (cons tzdata-zoneinfo-dir
+          (current-zoneinfo-search-path)))]
+  [_ (void)])


### PR DESCRIPTION
This fixes the problem of tzinfo not installing properly
on Windows. Plus it allows executables to be build with
raco exe that embed the zonefino files correctly.

Fixes #9 