### PR TITLE
Updates to work with new version of tzdata

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,10 +1,10 @@
 #lang info
 
 (define collection 'multi)
-(define version "0.3")
+(define version "0.4")
 (define deps (list "base"
                    "cldr-core"
                    "rackunit-lib"
-                   (list "tzdata" '#:platform 'windows '#:version "0.3")))
+                   (list "tzdata" '#:platform 'windows '#:version "0.4")))
 (define update-implies (list "tzdata"))
 (define build-deps '("racket-doc" "scribble-lib"))

--- a/tzinfo/private/zoneinfo.rkt
+++ b/tzinfo/private/zoneinfo.rkt
@@ -125,4 +125,12 @@
       "/"))))
 
 (define EXCLUDED-ZONEINFO-PATHS
-  '("+VERSION" "localtime" "posix" "posixrules" "right" "src" "Factory"))
+  '("+VERSION"
+    "leapseconds"
+    "localtime"
+    "posix"
+    "posixrules"
+    "right"
+    "src"
+    "tzinstall"
+    "Factory"))

--- a/tzinfo/scribblings/tzinfo.scrbl
+++ b/tzinfo/scribblings/tzinfo.scrbl
@@ -227,3 +227,16 @@ at the given local time in the given time zone, according to the tzinfo source.
 Returns the time zone ID currently in use by the operating system, if it can be detected,
 @racket[#f] otherwise.
 }
+
+@section{Building standalone executables that use @tt{tzinfo}}
+
+If you build a standalone executable (with @tt{raco exe}) that uses this library,
+you should keep in mind where you intend to deploy it. Most UNIX / MacOS systems
+come with the zoneinfo database installed, but Windows systems do not, nor do some
+minimal UNIX systems.
+
+To ensure that the target system will be able to find and use zoneinfo files,
+wherever you deploy your executable, you should install the @tt{tzdata} package.
+(When you install @tt{tzinfo} on a Windows system, @tt{tzdata} is automatically
+installed.) If @tt{tzdata} is installed, the zoneinfo files will be bundled with
+your executable when you use @tt{raco distribute}.


### PR DESCRIPTION
This fixes the problem of tzinfo not installing properly
on Windows. Plus it allows executables to be build with
raco exe that embed the zonefino files correctly.

This version does not require that `raco exe` be run
with a `++lib` argument.