### PR TITLE
Raise an informative error when the zoneinfo database isn't found

### DIFF
--- a/tzinfo/main.rkt
+++ b/tzinfo/main.rkt
@@ -10,7 +10,8 @@
          (struct-out tzgap)
          (struct-out tzoverlap)
          (struct-out exn:fail:tzinfo)
-         (struct-out exn:fail:tzinfo:zone-not-found))
+         (struct-out exn:fail:tzinfo:zone-not-found)
+         (struct-out exn:fail:tzinfo:zoneinfo-not-found))
 
 (define istring/c (and/c string? immutable?))
 

--- a/tzinfo/private/structs.rkt
+++ b/tzinfo/private/structs.rkt
@@ -45,3 +45,4 @@
 
 (struct exn:fail:tzinfo exn:fail () #:transparent)
 (struct exn:fail:tzinfo:zone-not-found exn:fail:tzinfo () #:transparent)
+(struct exn:fail:tzinfo:zoneinfo-not-found exn:fail:tzinfo () #:transparent)

--- a/tzinfo/private/zoneinfo.rkt
+++ b/tzinfo/private/zoneinfo.rkt
@@ -70,10 +70,35 @@
 
 (define (make-zoneinfo-source)
   (define dir (find-zoneinfo-directory))
+  (unless dir (raise-zoneinfo-not-found))
+
   (zoneinfo dir
             (read-tzids dir)
             (make-hash)
             (parse-tabfile dir)))
+
+(define (raise-zoneinfo-not-found)
+  (define (path-string->string ps)
+    (if (path? ps)
+        (path->string ps)
+        ps))
+
+  (raise
+   (exn:fail:tzinfo:zoneinfo-not-found
+    (apply
+     string-append
+     `("Unable to locate the zoneinfo database on this computer. "
+       "We searched for it in the following places:\n"
+       ,@(map (λ (path)
+                (string-append "  - " (path-string->string path) "\n"))
+              (current-zoneinfo-search-path))
+       "\n"
+       "Most likely, you need to install a package for your operating "
+       "system that contains the zoneinfo database. If the zoneinfo "
+       "database is already installed on your computer, please file a "
+       "bug report at https://github.com/97jaz/tzinfo/issues and mention "
+       "where on your filesystem it is installed."))
+    (current-continuation-marks))))
 
 (define (zoneinfo-zone zinfo tzid)
   (hash-ref! (zoneinfo-zones zinfo)

--- a/tzinfo/scribblings/tzinfo.scrbl
+++ b/tzinfo/scribblings/tzinfo.scrbl
@@ -160,6 +160,12 @@ Sets the constructor function that will be applied to build the default tzinfo s
 To use a custom source, you must call this function before using any of the querying functions.
 }
 
+@defstruct*[exn:fail:tzinfo:zoneinfo-not-found ()]{
+An exception that can be raised by any function that attempts to construct a
+@tt{zoneinfo}-based data source, when the @tt{zoneinfo} database cannot be
+found.
+}
+
 @section{Data Source Generics}
 
 @defmodule[tzinfo/source]

--- a/tzinfo/test/zoneinfo.rkt
+++ b/tzinfo/test/zoneinfo.rkt
@@ -62,3 +62,9 @@
   (check-exn exn:fail:tzinfo:zone-not-found?
              (λ ()
                (utc-seconds->tzoffset "Fillory/Whitespire" 675765756))))
+
+;; Check for proper error when we can't find the zoneinfo database
+(parameterize ([current-zoneinfo-search-path '("/path/to/nowhere")])
+  (check-exn exn:fail:tzinfo:zoneinfo-not-found?
+             (λ ()
+               (all-tzids))))


### PR DESCRIPTION
Fixes #8 
