### PR TITLE
check inode without following link (in case db tz is itself a symlink)

### DIFF
--- a/tzinfo/private/os/unix.rkt
+++ b/tzinfo/private/os/unix.rkt
@@ -38,7 +38,7 @@
   (for*/first ([tzid (in-list all-tzids)]
                [f (in-value (build-path base-path tzid))]
                #:when (and (file-exists? f)
-                           (= inode (file-or-directory-identity f))))
+                           (= inode (file-or-directory-identity f #t))))
     tzid))
 
 ;; Older versions of OS X, instead of symlinking /etc/localtime to


### PR DESCRIPTION
In some setups timezone files are symlinked to others.  For example, America/Montreal is symlinked to America/Toronto.
When checking /etc/localtime the target file should be checked with #t for `as-link?` so that you will only find the actual file that's linked to, rather than to another file that links to the same file.