### PR TITLE
Look for the tzdata package's zoneinfo files in shared directory

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,10 +1,10 @@
 #lang info
 
 (define collection 'multi)
-(define version "0.4")
-(define deps (list "base"
+(define version "0.5")
+(define deps (list (list "base" '#:version "7.5.0.7")
                    "cldr-core"
                    "rackunit-lib"
-                   (list "tzdata" '#:platform 'windows '#:version "0.4")))
+                   (list "tzdata" '#:platform 'windows '#:version "0.5")))
 (define update-implies (list "tzdata"))
 (define build-deps '("racket-doc" "scribble-lib"))

--- a/tzinfo/private/zoneinfo.rkt
+++ b/tzinfo/private/zoneinfo.rkt
@@ -3,8 +3,10 @@
 (require racket/contract/base
          racket/path
          racket/match
+         racket/runtime-path
          racket/set
-         racket/string)
+         racket/string
+         (for-syntax racket/base))
 (require "generics.rkt"
          "structs.rkt"
          "os/unix.rkt"
@@ -115,8 +117,12 @@
         "/usr/share/lib/zoneinfo"
         "/etc/zoneinfo"))
 
+;; If the tzdata package (ver. >= 0.5) is installed, its zoneinfo
+;; directory will be here.
+(define-runtime-path tzdata-zoneinfo-path '(share "tzdata/zoneinfo"))
+
 (define current-zoneinfo-search-path
-  (make-parameter default-zoneinfo-search-path))
+  (make-parameter (cons tzdata-zoneinfo-path default-zoneinfo-search-path)))
 
 (define (find-zoneinfo-directory [path-list (current-zoneinfo-search-path)])
   (for/first ([path (in-list path-list)]

--- a/tzinfo/zoneinfo.rkt
+++ b/tzinfo/zoneinfo.rkt
@@ -1,31 +1,9 @@
 #lang racket/base
 
-(require racket/contract/base
-         racket/runtime-path
-         (for-syntax racket/base
-                     racket/match
-                     setup/getinfo))
+(require racket/contract/base)
 (require "private/generics.rkt"
          "private/zoneinfo.rkt")
 
 (provide/contract
  [current-zoneinfo-search-path (parameter/c (listof path-string?))]
  [make-zoneinfo-source         (-> tzinfo-source?)])
-
-
-;; If the tzdata package is installed, put its zoneinfo directory at
-;; the head of the search path.
-(define-syntax (detect-tzdata stx)
-  (syntax-case stx ()
-    [(_)
-     (match (find-relevant-directories '(tzdata-zoneinfo-module-path))
-       [(cons info-dir _)
-        (let ([path ((get-info/full info-dir) 'tzdata-zoneinfo-module-path)])
-          #`(begin
-              (define-runtime-path tzdata-path '#,path)
-              (current-zoneinfo-search-path
-               (cons (simplify-path tzdata-path)
-                     (current-zoneinfo-search-path)))))]
-       [_ #'(void)])]))
-
-(detect-tzdata)


### PR DESCRIPTION
The new version of tzdata copies its zoneinfo files into a shared
directory. tzinfo will now look for them there. The advantage of
this approach is that it should work with raco distribute.

See https://github.com/97jaz/tzdata/pull/7