### PR TITLE
Remove the version restriction on base

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,8 +1,8 @@
 #lang info
 
 (define collection 'multi)
-(define version "0.5")
-(define deps (list (list "base" '#:version "7.5.0.7")
+(define version "0.6")
+(define deps (list "base"
                    "cldr-core"
                    "rackunit-lib"
                    (list "tzdata" '#:platform 'windows '#:version "0.5")))


### PR DESCRIPTION
The previous version of this package declared that it requires
version 7.5.0.7 or later of base. But since the racket package
system doesn't really support having multiple versions of a
package that have different dependencies, that didn't work out
so well.

This change removes the version restriction on base by handling
older Racket versions differently from newer ones. On older
versions, we won't even try to support using tzdata-supplied
files along with raco distribute. However, tzdata-supplied files
should work just fine outside of raco distribute. Newer versions
of Racket will get proper raco distribute support.